### PR TITLE
Refactor stdlib_printing.h

### DIFF
--- a/stdlib_printing.hh
+++ b/stdlib_printing.hh
@@ -4,68 +4,66 @@
 #include <map>
 #include <vector>
 #include <set>
-#include <utility>
 #include <iostream>
 
 using namespace std;
 
+
+template <typename Structure, typename Function>
+ostream& print_all(
+  ostream& os,
+  const string prefix,
+  const Structure& v,
+  const Function print_item,
+  const string suffix
+) {
+  os << prefix;
+  for(auto it = v.begin(); it != v.end(); it++) {
+    if(it != v.begin()) os << ", ";
+    print_item(os, *it);
+  }
+  os << suffix;
+  return os;
+}
+
+template <typename T>
+void print_individual(ostream& os, const T& item) {
+  os << item;
+}
+
+template <typename T>
+void print_first_second(ostream& os, const T& item) {
+  os << item.first << ": " << item.second;
+}
+
+
 template <typename S, typename T>
 ostream& operator<<(ostream& os, const unordered_map<S,T>& v){
-    os << "[";
-    for(auto it = v.begin(); it != v.end(); it++) {
-        if(it != v.begin()) os << ", ";
-        os << it->first << ": " << it->second;
-    }
-    os << "]";
-    return os;
+  return print_all<typeof(v)>(os, "[", v, print_first_second<pair<S, T>>, "]");
 }
 
 template <typename S, typename T>
 ostream& operator<<(ostream& os, const map<S,T>& v){
-    os << "{";
-    for(auto it = v.begin(); it != v.end(); it++) {
-        if(it != v.begin()) os << ", ";
-        os << it->first << ": " << it->second;
-    }
-    os << "}";
-    return os;
+  return print_all<typeof(v)>(os, "{", v, print_first_second<pair<S, T>>, "}");
 }
 
 template <typename T>
 ostream& operator<<(ostream& os, const vector<T>& v){
-    os << "[";
-    for(auto it = v.begin(); it != v.end(); it++) {
-        if(it != v.begin()) os << ", ";
-        os << *it;
-    }
-    os << "]";
-    return os;
+  return print_all<typeof(v)>(os, "[", v, print_individual<T>, "]");
 }
 
 template <typename T>
 ostream& operator<<(ostream& os, const set<T>& v){
-    os << "[";
-    for(auto it = v.begin(); it != v.end(); it++) {
-        if(it != v.begin()) os << ", ";
-        os << *it;
-    }
-    os << "]";
-    return os;
+  return print_all<typeof(v)>(os, "[", v, print_individual<T>, "]");
 }
 
 template <typename T>
 ostream& operator<<(ostream& os, const multiset<T>& v){
-    os << "[";
-    for(auto it = v.begin(); it != v.end(); it++) {
-        if(it != v.begin()) os << ", ";
-        os << *it;
-    }
-    os << "]";
-    return os;
+  return print_all<typeof(v)>(os, "[", v, print_individual<T>, "]");
 }
 
 template <typename S, typename T>
 ostream& operator<<(ostream& os, const pair<S,T>& x){
-    os << "(" << x.first << ", " << x.second << ")";
-    return os;
+  os << "(" << x.first << ", " << x.second << ")";
+  return os;
 }

--- a/stdlib_printing.hh
+++ b/stdlib_printing.hh
@@ -6,7 +6,14 @@
 #include <set>
 #include <iostream>
 
-using namespace std;
+using std::set;
+using std::map;
+using std::vector;
+using std::unordered_map;
+using std::ostream;
+using std::pair;
+using std::multiset;
+using std::string;
 
 
 template <typename Structure, typename Function>

--- a/test_print.cpp
+++ b/test_print.cpp
@@ -1,0 +1,42 @@
+/*
+Tests the functions inside of stdlib_printing.hh
+*/
+
+
+#include <unordered_map>
+#include <map>
+#include <vector>
+#include <set>
+#include <iostream>
+#include "stdlib_printing.hh"
+
+
+using namespace std;
+
+int main() {
+  unordered_map<int, string> um = {
+    {2, "two"},
+    {3, "three"},
+    {5, "five"}
+  };
+  cout << um << endl;
+
+  map<int, string> m = {
+    {2, "two"},
+    {3, "three"},
+    {5, "five"}
+  };
+  cout << m << endl;
+
+  vector<int> v = {2, 2, 3, 5};
+  cout << v << endl;
+
+  set<int> s = {2, 2, 3, 5};
+  cout << s << endl;
+
+  multiset<int> ms = {2, 2, 3, 5};
+  cout << ms << endl;
+
+  pair<int, string> p = {2, "two"};
+  cout << p << endl;
+}


### PR DESCRIPTION
These changes:
* Eliminate code repeats
* Removes using namespace std which could break things in the future
* Makes the code more scalable (easier to print more data structures in the future)
* Provide a test bench for stdlib_printing.hh (informal testing, Google Test might be a bit overkill for this 'toy' case)